### PR TITLE
[17.0][MIG] hr_timesheet_sheet : Migration to V17

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "HR Timesheet Sheet",
-    "version": "16.0.1.1.0",
+    "version": "17.0.1.0.0",
     "category": "Human Resources",
     "sequence": 80,
     "summary": "Timesheet Sheets, Activities",

--- a/hr_timesheet_sheet/models/account_analytic_account.py
+++ b/hr_timesheet_sheet/models/account_analytic_account.py
@@ -12,7 +12,7 @@ class AccountAnalyticAccount(models.Model):
     def _check_timesheet_sheet_company_id(self):
         for rec in self.sudo():
             sheets = rec.line_ids.mapped("sheet_id").filtered(
-                lambda s: s.company_id and s.company_id != rec.company_id
+                lambda s, rec=rec: s.company_id and rec.company_id != s.company_id
             )
             if sheets:
                 raise ValidationError(

--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -135,5 +135,16 @@ class AccountAnalyticLine(models.Model):
         self[1:].unlink()
         return self[0]
 
-    def _check_can_update_timesheet(self):
-        return super()._check_can_update_timesheet() or not self.filtered("sheet_id")
+    def _check_can_write(self, values):
+        if not self.env.su:
+            if self.holiday_id and values.get(
+                "sheet_id", False
+            ):  # Dont raise error during create
+                return True
+            if self.holiday_id and self.sheet_id:
+                raise UserError(
+                    _(
+                        "You cannot modify timesheets that are linked to time off requests. Please use the Time Off application to modify your time off requests instead."
+                    )
+                )
+        return super()._check_can_write(values)

--- a/hr_timesheet_sheet/static/description/index.html
+++ b/hr_timesheet_sheet/static/description/index.html
@@ -9,10 +9,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +276,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +302,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -471,7 +472,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -373,7 +373,7 @@ class TestHrTimesheetSheet(TransactionCase):
                 line_form.unit_amount = 1.0
                 self.assertEqual(len(sheet.new_line_ids), 1)
         line2 = fields.first(
-            sheet.line_ids.filtered(lambda l: l.date != timesheet.date)
+            sheet.line_ids.filtered(lambda x: x.date != timesheet.date)
         )
         self.assertEqual(line2.unit_amount, 1.0)
         self.assertEqual(len(sheet.timesheet_ids), 2)
@@ -473,7 +473,7 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(timesheet_1_or_2.unit_amount, 1.0)
         self.assertEqual(timesheet_3.unit_amount, 0.0)
 
-        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line = sheet.line_ids.filtered(lambda x: x.unit_amount != 0.0)
         self.assertEqual(len(line), 1)
         self.assertEqual(line.unit_amount, 1.0)
 
@@ -526,7 +526,7 @@ class TestHrTimesheetSheet(TransactionCase):
             pass  # trigger edit and save
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 2)
-        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line = sheet.line_ids.filtered(lambda x: x.unit_amount != 0.0)
         self.assertEqual(line.unit_amount, 4.0)
 
         timesheet_2.name = empty_name
@@ -622,7 +622,7 @@ class TestHrTimesheetSheet(TransactionCase):
             pass  # trigger edit and save
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 5)
-        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line = sheet.line_ids.filtered(lambda x: x.unit_amount != 0.0)
         self.assertEqual(line.unit_amount, 10.0)
 
         timesheet_2.name = empty_name
@@ -652,7 +652,7 @@ class TestHrTimesheetSheet(TransactionCase):
                 line_form.unit_amount = 3.0
                 self.assertEqual(len(sheet.new_line_ids), 1)
         self.assertEqual(len(sheet.timesheet_ids), 4)
-        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line = sheet.line_ids.filtered(lambda x: x.unit_amount != 0.0)
         self.assertEqual(line.unit_amount, 3.0)
 
         timesheet_3_4_and_5 = self.aal_model.search(
@@ -676,7 +676,7 @@ class TestHrTimesheetSheet(TransactionCase):
         with Form(sheet.with_user(self.user)):
             pass  # trigger edit and save
         self.assertEqual(len(sheet.timesheet_ids), 4)
-        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line = sheet.line_ids.filtered(lambda x: x.unit_amount != 0.0)
         self.assertEqual(len(line), 1)
         self.assertEqual(line.unit_amount, 5.0)
 
@@ -866,7 +866,7 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(len(sheet.line_ids), 7)
 
-        line = sheet.line_ids.filtered(lambda l: l.unit_amount)
+        line = sheet.line_ids.filtered(lambda x: x.unit_amount)
         self.assertEqual(len(line), 1)
         self.assertEqual(line.unit_amount, 2.0)
 

--- a/hr_timesheet_sheet/views/account_analytic_line_views.xml
+++ b/hr_timesheet_sheet/views/account_analytic_line_views.xml
@@ -12,10 +12,7 @@
         <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form" />
         <field name="arch" type="xml">
             <field name="date" position="after">
-                <field
-                    name="sheet_id"
-                    attrs="{'invisible': [('sheet_id', '=', False)]}"
-                />
+                <field name="sheet_id" invisible="not sheet_id" />
             </field>
         </field>
     </record>

--- a/hr_timesheet_sheet/views/hr_department_views.xml
+++ b/hr_timesheet_sheet/views/hr_department_views.xml
@@ -40,7 +40,7 @@
                         </a>
                     </div>
                     <div class="col-xs-3">
-                        <t t-esc="record.timesheet_sheet_to_approve_count.raw_value" />
+                        <t t-out="record.timesheet_sheet_to_approve_count.raw_value" />
                     </div>
                 </div>
             </xpath>
@@ -52,7 +52,7 @@
                             type="action"
                         >
                             <t
-                                t-esc="record.timesheet_sheet_to_approve_count.raw_value or 0"
+                                t-out="record.timesheet_sheet_to_approve_count.raw_value or 0"
                             /> Timesheets
                         </a>
                     </div>

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -17,13 +17,13 @@
             >
                 <field name="employee_id" />
                 <field name="name" string="Period" />
-                <field name="department_id" invisible="1" />
+                <field name="department_id" column_invisible="True" />
                 <field name="date_start" />
                 <field name="date_end" />
                 <field name="reviewer_id" />
                 <field name="state" />
                 <field name="total_time" widget="float_time" />
-                <field name="message_needaction" invisible="1" />
+                <field name="message_needaction" column_invisible="True" />
             </tree>
         </field>
     </record>
@@ -35,7 +35,7 @@
         <field name="priority">1000</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='employee_id']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
         </field>
     </record>
@@ -53,26 +53,26 @@
                         string="Submit to Reviewer"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible': [('state', '!=', 'draft')]}"
+                        invisible="state != 'draft'"
                     />
                     <button
                         name="action_timesheet_done"
                         string="Approve"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible': ['|', ('can_review', '!=', True), ('state', '!=', 'confirm')]}"
+                        invisible="not can_review or state != 'confirm'"
                     />
                     <button
                         name="action_timesheet_draft"
                         string="Set to Draft"
                         type="object"
-                        attrs="{'invisible': ['|', ('can_review', '!=', True), ('state', '!=', 'done')]}"
+                        invisible="not can_review or state != 'done'"
                     />
                     <button
                         name="action_timesheet_refuse"
                         string="Refuse"
                         type="object"
-                        attrs="{'invisible': ['|', ('can_review', '!=', True), ('state', '!=', 'confirm')]}"
+                        invisible="not can_review or state != 'confirm'"
                     />
                     <field
                         name="state"
@@ -89,6 +89,7 @@
                                 name="employee_id"
                                 class="oe_inline"
                                 placeholder="Employee's Name"
+                                readonly="state != 'new'"
                             />
                         </h1>
                     </div>
@@ -98,7 +99,12 @@
                             <div style="display: inline;"><field
                                     name="date_start"
                                     class="oe_inline"
-                                /> to <field name="date_end" class="oe_inline" /></div>
+                                    readonly="state != 'new'"
+                                /> to <field
+                                    name="date_end"
+                                    class="oe_inline"
+                                    readonly="state != 'new'"
+                                /></div>
                         </group>
                         <group name="details">
                             <field name="company_id" force_save="1" />
@@ -112,7 +118,7 @@
                                 <field
                                     name="line_ids"
                                     nolabel="1"
-                                    attrs="{'readonly': [('state', 'not in', ['new', 'draft'])]}"
+                                    readonly="state not in ('new', 'draft')"
                                     widget="x2many_2d_matrix"
                                     field_x_axis="value_x"
                                     field_y_axis="value_y"
@@ -142,13 +148,13 @@
                                 </field>
                                 <group
                                     class="oe_edit_only"
-                                    attrs="{'invisible': [('state', 'not in', ['new', 'draft'])]}"
+                                    invisible="state not in ('new', 'draft')"
                                 >
                                     <field name="add_line_project_id" />
                                     <field name="available_task_ids" invisible="1" />
                                     <field
                                         name="add_line_task_id"
-                                        attrs="{'invisible': [('add_line_project_id', '=', False)]}"
+                                        invisible="not add_line_project_id"
                                         context="{'default_project_id': add_line_project_id}"
                                     />
                                     <button
@@ -157,7 +163,7 @@
                                         colspan="2"
                                         string="Add new line"
                                         class="oe_highlight"
-                                        attrs="{'invisible': [('add_line_project_id', '=', False)]}"
+                                        invisible="not add_line_project_id"
                                     />
                                 </group>
                             </group>
@@ -167,6 +173,7 @@
                                 name="timesheet_ids"
                                 nolabel="1"
                                 context="{'user_id': user_id}"
+                                readonly="state not in ('new','draft')"
                             >
                                 <tree editable="bottom">
                                     <field name="date" />
@@ -254,10 +261,10 @@
                                 </div>
                                 <div class="col-10">
                                     <strong class="o_kanban_record_title">
-                                        <t t-esc="record.employee_id.value" />
+                                        <t t-out="record.employee_id.value" />
                                     </strong>
                                     <div class="text-muted o_kanban_record_subtitle">
-                                        <t t-esc="record.complete_name.value" />
+                                        <t t-out="record.complete_name.value" />
                                     </div>
                                     <div
                                         class="o_dropdown_kanban dropdown"
@@ -323,8 +330,8 @@
                                     <span class="text-muted text-nowrap">Period</span>
                                 </div>
                                 <div class="col-7"><t
-                                        t-esc="record.date_start.value"
-                                    /> - <t t-esc="record.date_end.value" /></div>
+                                        t-out="record.date_start.value"
+                                    /> - <t t-out="record.date_end.value" /></div>
                                 <div class="w-100" />
                                 <div class="col-3">
                                     <span
@@ -333,8 +340,8 @@
                                 </div>
                                 <div class="col-7">
                                     <t
-                                        t-esc="record.total_time.value"
-                                        t-options="{'widget': 'float_time'}"
+                                        t-out="record.total_time.value"
+                                        options="{'widget': 'float_time'}"
                                     />
                                 </div>
                             </div>

--- a/hr_timesheet_sheet/views/res_config_settings_views.xml
+++ b/hr_timesheet_sheet/views/res_config_settings_views.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <!--
         Copyright 2019-2020 Brainbean Apps (https://brainbeanapps.com)
@@ -10,10 +10,7 @@
         <field name="priority" eval="55" />
         <field name="inherit_id" ref="hr_timesheet.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//div[hasclass('settings')]/div[@groups='hr_timesheet.group_timesheet_manager']/div[position()=1]"
-                position="after"
-            >
+            <app position="inside">
                 <h2>Timesheet Options</h2>
                 <div class="row mt16 o_settings_container" name="hr_timesheet_sheet">
                     <div class="col-xs-12 col-md-6 o_setting_box">
@@ -43,7 +40,8 @@
                     </div>
                     <div
                         class="col-xs-12 col-md-6 o_setting_box"
-                        attrs="{'invisible':[('sheet_range','!=','WEEKLY')], 'required':[('sheet_range','=','WEEKLY')]}"
+                        invisible="sheet_range != 'WEEKLY'"
+                        required="sheet_range == 'WEEKLY'"
                     >
                         <div class="o_setting_right_pane">
                             <label for="timesheet_week_start" />
@@ -95,7 +93,7 @@
                         </div>
                     </div>
                 </div>
-            </xpath>
+            </app>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
We found few problems and created PR to resolve the below errors for https://github.com/OCA/timesheet/pull/629

The compute field "Timesheet Sheets to Approve" is causing the following error: "tuple indices must be integers or slices, not str."
View attributes have not been migrated to version 17 code standards